### PR TITLE
Fixed issue-toc galley display correction to an unintended line break

### DIFF
--- a/templates/frontend/objects/issue_toc.tpl
+++ b/templates/frontend/objects/issue_toc.tpl
@@ -110,8 +110,7 @@
                         {translate key="issue.fullIssue"}
                 </h2>
                 {foreach from=$issueGalleys item=galley}
-                        {include file="frontend/objects/galley_link.tpl" parent=$issue labelledBy="issueTocGalleyLabel" purchaseFee=$currentJ
-ournal->getData('purchaseIssueFee') purchaseCurrency=$currentJournal->getData('currency')}
+                        {include file="frontend/objects/galley_link.tpl" parent=$issue labelledBy="issueTocGalleyLabel" purchaseFee=$currentJournal->getData('purchaseIssueFee') purchaseCurrency=$currentJournal->getData('currency')}
                 {/foreach}
         </section>
 {/if}


### PR DESCRIPTION
There is an unintended line break on line 113 that throws error when gopher theme is used in OJS 3.3 installation on my server. I was able to locate the error using AI debugging tools as an unintended line break on line 113. 